### PR TITLE
[PS-227] Feature: Create Label Component

### DIFF
--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -1,0 +1,33 @@
+import { cn } from '@/utils/twmerge';
+import React from 'react';
+
+interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
+  variant?: keyof typeof labelVariants.variant;
+}
+
+const labelStyleBase = 'text-sm font-medium';
+
+const labelVariants = {
+  variant: {
+    primary: `${labelStyleBase} text-custom-purple`,
+    secondary: `${labelStyleBase} text-[#2E2E2E]`,
+  },
+};
+
+const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
+  ({ htmlFor, variant = 'primary', className, children, ...props }, ref) => {
+    return (
+      <label
+        htmlFor={htmlFor}
+        className={(cn(labelVariants.variant[variant]), className)}
+        ref={ref}
+        {...props}
+      >
+        {children}
+      </label>
+    );
+  },
+);
+Label.displayName = 'Label';
+
+export { Label };


### PR DESCRIPTION
# Pull Request em desenvolvimento:

### 1. Componetização do Label

   - **Criação de um Componente Reutilizável:**
      - Introdução do componente `Label` sendo uma extensão da tag HTML `<label>`.
         
   - **Variantes de estilo:**
      - `primary`: Estilo com label roxo
      - `secondary`: Estilo com label preto.
 
   - **Integração com Tailwind CSS:**
       - Utilização de classes do Tailwind CSS para estilização.
       - Combinação dinâmica de classes utilizando `twMerge`.