### PR TITLE
[PS-227] Feature: Create Logo Component

### DIFF
--- a/src/app/(auth)/change-password/page.tsx
+++ b/src/app/(auth)/change-password/page.tsx
@@ -1,15 +1,10 @@
-import Image from 'next/image';
 import { ChangePasswordForm } from './components/ChangePasswordForm';
+import { Logo } from '@/components/Logo';
 
 export default function ChangePasswordPage() {
   return (
     <>
-      <Image
-        src="/images/logo.svg"
-        alt="Pet Journal Logo"
-        width={158}
-        height={158}
-      />
+      <Logo scale='lg' />
       <h1 className="font-medium text-2xl">Criar uma nova senha?</h1>
       <div className="w-full max-w-sm mt-8">
         <ChangePasswordForm />

--- a/src/app/(auth)/forget-password/page.tsx
+++ b/src/app/(auth)/forget-password/page.tsx
@@ -1,15 +1,11 @@
 import Image from 'next/image';
 import { ForgetPasswordForm } from './components/ForgetPasswordForm';
+import { Logo } from '@/components/Logo';
 
 export default function ForgetPasswordPage() {
   return (
     <>
-      <Image
-        src="/images/logo.svg"
-        alt="Pet Journal Logo"
-        width={158}
-        height={158}
-      />
+      <Logo scale='lg' />
       <div className="flex flex-col justify-center">
         <h1 className="font-medium text-2xl text-center">Esqueceu a senha?</h1>
         <p className="text-center">Redefina a senha em duas etapas</p>

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,16 +1,11 @@
-import Image from 'next/image';
 import Link from 'next/link';
 import { LoginForm } from './components/LoginForm';
+import { Logo } from '@/components/Logo';
 
 export default function LoginPage() {
   return (
     <>
-      <Image
-        src="/images/logo.svg"
-        alt="Pet Journal Logo"
-        width={158}
-        height={158}
-      />
+      <Logo scale='lg' />
       <h1 className="font-medium text-2xl">Acessar conta</h1>
       <div className="w-full max-w-sm m-auto">
         <LoginForm />

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -2,20 +2,14 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { FormEvent } from 'react';
 import { RegisterForm } from './components/RegisterForm';
+import { Logo } from '@/components/Logo';
 
 export default function RegisterPage() {
   function submitRegister(form: FormEvent<HTMLFormElement>) {}
 
   return (
     <>
-      <Image
-        className="w-28"
-        src="/images/logo.svg"
-        alt="Pet Journal Logo"
-        width={158}
-        height={158}
-        quality={100}
-      />
+      <Logo scale='md' />
       <h1 className="font-medium text-2xl">Inscreva-se</h1>
       <div className="w-full max-w-sm">
         <RegisterForm />

--- a/src/app/(auth)/waiting-code/page.tsx
+++ b/src/app/(auth)/waiting-code/page.tsx
@@ -1,16 +1,12 @@
 import Image from 'next/image';
 import { WaitingCodeForm } from './components/WaitingCodeForm';
 import { Suspense } from 'react';
+import { Logo } from '@/components/Logo';
 
 export default function WaitingCodePage() {
   return (
     <>
-      <Image
-        src="/images/logo.svg"
-        alt="Pet Journal Logo"
-        width={158}
-        height={158}
-      />
+      <Logo scale="lg" />
       <div className="flex flex-col justify-center gap-4">
         <h1 className="font-medium text-2xl text-center">
           Acabamos de enviar um código para seu e-mail

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,14 +1,12 @@
+import { Logo } from '@/components/Logo';
 import Image from 'next/image';
 import Link from 'next/link';
 
 export default function NotFound() {
   return (
     <div className="min-h-screen flex flex-col justify-center items-center p-8">
-      <Image
-        src="/images/logo.svg"
-        alt="Pet Journal Logo"
-        width={158}
-        height={158}
+      <Logo
+       scale='lg'
       />
       <h2 className="font-medium text-2xl text-center">
         Página não encontrada...

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -29,15 +29,17 @@ const logoVariants = {
 
 export interface LogoProps {
   scale?: keyof typeof logoVariants.scale;
+  className?: string;
 }
 
-export function Logo({ scale = 'default' }: LogoProps) {
+export function Logo({ scale = 'default', className }: LogoProps) {
   return (
     <Image
       src="/images/logo.svg"
       height={logoVariants.scale[scale].height}
       width={logoVariants.scale[scale].width}
       alt="Pet Journal Logo"
+      className={className}
     />
   );
 }

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,0 +1,43 @@
+import { cn } from '@/utils/twmerge';
+import Image, { ImageProps } from 'next/image';
+import { Ref, forwardRef } from 'react';
+
+const logoVariants = {
+  scale: {
+    default: {
+      width: 37,
+      height: 36.42,
+    },
+    md: {
+      width: 76,
+      height: 76,
+    },
+    lg: {
+      width: 158,
+      height: 158,
+    },
+    xl: {
+      width: 201.74,
+      height: 171,
+    },
+    '2xl': {
+      width: 342.13,
+      height: 290,
+    },
+  },
+};
+
+export interface LogoProps {
+  scale?: keyof typeof logoVariants.scale;
+}
+
+export function Logo({ scale = 'default' }: LogoProps) {
+  return (
+    <Image
+      src="/images/logo.svg"
+      height={logoVariants.scale[scale].height}
+      width={logoVariants.scale[scale].width}
+      alt="Pet Journal Logo"
+    />
+  );
+}


### PR DESCRIPTION
### Esta PR conclui os seguintes objetivos:

1. #### Componentização da Logo
   - **Criação de um Componente Reutilizável**:
     - Componente `Logo` que retorna a logo principal.
   - **Propriedades Personalizadas**:
     - Suporte para a propriedade `scale` que permite a escolha de diferentes tamanhos da imagem (predefinidos no figma).
     
### Preview
![Preview](https://github.com/PetJournal/petjournal.web/assets/76531786/b4a1d271-875c-440d-a0cb-51da59e48813)

